### PR TITLE
optional exclusion of event triggers #2fmfkhh

### DIFF
--- a/metrics/src/collectors/event_triggers.rs
+++ b/metrics/src/collectors/event_triggers.rs
@@ -72,6 +72,9 @@ fn create_event_trigger_request() -> SQLRequest {
 }
 
 pub(crate) async fn check_event_triggers(cfg: &Configuration) {
+    if cfg.exclude_collectors.contains("event_triggers") {
+        return
+    }
     let sql_result = make_sql_request(&create_event_trigger_request(), cfg).await;
     match sql_result {
         Ok(v) => {

--- a/metrics/src/main.rs
+++ b/metrics/src/main.rs
@@ -50,6 +50,7 @@ pub(crate) struct Configuration {
     log_file: String,
     sleep_time: u64,
     collect_interval: u64,
+    exclude_collectors: String,
 }
 
 impl Default for Configuration {
@@ -99,6 +100,13 @@ impl Default for Configuration {
                     .env("HASURA_GRAPHQL_ADMIN_SECRET")
                     .required(true)
                     .takes_value(true),
+            )
+            .arg(
+                Arg::new("exclude_collectors")
+                    .long("exclude_collectors")
+                    .env("EXCLUDE_COLLECTORS")
+                    .default_value("")
+                    .takes_value(true),
             ).get_matches();
 
         Configuration {
@@ -112,6 +120,7 @@ impl Default for Configuration {
             collect_interval: matches
                 .value_of_t("collect-interval")
                 .expect("can't configure collect-interval time"),
+            exclude_collectors: matches.value_of("exclude_collectors").expect("required").to_string(),
         }
     }
 }


### PR DESCRIPTION
We were getting constant errors about the event_log not existing, which
is either a difference in hasura 2.6+ or the fact that we aren't using
events.